### PR TITLE
parsing json body when the test run single time

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ const getMessageAttributes = require('./getMessageAttributes');
 exports.handler = function (event) {
   console.log('...starting test-route-packager with payload --> ', event);
 
+	if (!event.test) {
+		event = JSON.parse(event.body);
+	}
+
   const region = 'us-east-1';
   AWS.config.update({ region });
 


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

- added just this line: 
```javascript
	if (!event.test) {
		event = JSON.parse(event.body);
	}
```
It is needed because when event is send directly from a URL it is packed in an envelope and the json body is a json string:
```javascript
{
  version: '2.0',
  routeKey: '$default',
  rawPath: '/',
  rawQueryString: '',
  headers: {
    'content-length': '301',
    'x-amzn-tls-cipher-suite': 'ECDHE-RSA-AES128-GCM-SHA256',
    'x-amzn-tls-version': 'TLSv1.2',
    'x-amzn-trace-id': 'Root=1-62d9d875-4590c8cb0b6bab276b8170f8',
    'x-forwarded-proto': 'https',
    host: '7a3syeh3lbbo6tbrdss72llcau0olbyo.lambda-url.us-east-1.on.aws',
    'x-forwarded-port': '443',
    'content-type': 'application/json',
    'x-forwarded-for': '85.226.178.219',
    accept: 'application/json, text/plain, */*',
    'user-agent': 'axios/0.27.2'
  },
  requestContext: {
    accountId: 'anonymous',
    apiId: '7a3syeh3lbbo6tbrdss72llcau0olbyo',
    domainName: '7a3syeh3lbbo6tbrdss72llcau0olbyo.lambda-url.us-east-1.on.aws',
    domainPrefix: '7a3syeh3lbbo6tbrdss72llcau0olbyo',
    http: {
      method: 'POST',
      path: '/',
      protocol: 'HTTP/1.1',
      sourceIp: '85.226.178.219',
      userAgent: 'axios/0.27.2'
    },
    requestId: '1eeaeab7-e999-427b-b672-a13cd947afe6',
    routeKey: '$default',
    stage: '$default',
    time: '21/Jul/2022:22:51:33 +0000',
    timeEpoch: 1658443893665
  },
  body: '{"test":{"title":"tim-E2E-1-22-pm","locations":["us-west-1"],"minutesBetweenRuns":1,"type":"API","httpRequest":{"method":"get","url":"https://trellific.corkboard.dev/api/boards","headers":null,"body":null,"assertions":[{"type":"statuscode","property":null,"expected_value":"404","name":"equal_to"}]}}}',
  isBase64Encoded: false
}
```